### PR TITLE
Switch to using master for agama-wallet-lib

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -30,7 +30,7 @@
   "author": "SuperNET Team",
   "license": "MIT",
   "dependencies": {
-    "agama-wallet-lib": "git://github.com/VerusCoin/agama-wallet-lib.git#dev",
+    "agama-wallet-lib": "git://github.com/VerusCoin/agama-wallet-lib.git",
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.14.0",


### PR DESCRIPTION
Now that the master branch of agama-wallet-lib is setup and working,  switch to using master branch from the fork of it in the VerusCoin github org.